### PR TITLE
Added an environment file for Docker and the mysql image

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=root_password
+MYSQL_USER=user
+MYSQL_PASSWORD=password
+MYSQL_DATABASE=mowlkky

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Parameters
 /app/config/parameters.yml
 /app/config/parameters.ini
+.env
 
 # Managed by Composer
 /app/bootstrap.php.cache

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Clone the repository first :
 git clone https://github.com/Wanimo/MoWlkky.git
 ```
 
+Copy the ``/.env.dist`` file and create a ``/.env`` file with database parameters.
+
 Then build and start Docker to have an operational dev environment :
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,7 @@ db:
     image: mysql:5.7
     ports:
         - "3306:3306"
-    environment:
-        - "MYSQL_ROOT_PASSWORD=m0WlI<I<y"
-        - "MYSQL_USER=dev"
-        - "MYSQL_PASSWORD=mowlkky_dev"
-        - "MYSQL_DATABASE=mowlkky"
-
+    env_file: .env
 
 composer:
     image: composer/composer


### PR DESCRIPTION
With this PR, the MySQL parameters are no longer saved in the docker-compose.yml file.

I replaced it with an .env and .env.dist files, it works in the same way as Symfony with the parameters.

This PR should be tested on your dev environment before merging it.

Close #2 